### PR TITLE
fix: allow open to run async on linux

### DIFF
--- a/lib/src/platform/open_filex.dart
+++ b/lib/src/platform/open_filex.dart
@@ -30,7 +30,7 @@ class OpenFilex {
         var filePathLinux = Uri.file(filePath!);
         if (linuxByProcess) {
           result =
-              Process.runSync('xdg-open', [filePathLinux.toString()]).exitCode;
+              (await Process.run('xdg-open', [filePathLinux.toString()])).exitCode;
         } else {
           result = linux
               .system(['$linuxDesktopName-open', filePathLinux.toString()]);


### PR DESCRIPTION
The whole function is already async, so it would make sense to be able to open a file without blocking. Unluckily, this small fix only works if the `linuxByProcess` flag is true.