### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_filex
 description: A plug-in that can call native APP to open files with string result in flutter, support iOS(UTI) / android(intent) / PC(ffi) / web(dart:html)
-version: 4.4.0
+version: 4.4.1
 homepage: https://github.com/javaherisaber/open_file
 
 dependencies:
@@ -25,10 +25,10 @@ flutter:
       ios:
         pluginClass: OpenFilePlugin
       windows:
-        default_package: open_filex
+        default_package: dartPluginClass
       linux:
-        default_package: open_filex
+        default_package: dartPluginClass
       macos:
-        default_package: open_filex
+        default_package: dartPluginClass
       web:
         default_package: open_filex


### PR DESCRIPTION
After running flutter upgrade & flutter pub upgrade --major-versions, I received the following error when trying to build my Flutter app resulting in the inability to build/run my app:

```
Launching lib/main.dart on iPhone SE (3rd generation) in debug mode... Package open_filex:linux references open_filex:linux as the default plugin, but it does not provide an inline implementation. Ask the maintainers of open_filex to either avoid referencing a default implementation via `platforms: linux: default_package: open_filex` or add an inline implementation to open_filex via `platforms: linux:` `pluginClass` or `dartPluginClass`.

Package open_filex:macos references open_filex:macos as the default plugin, but it does not provide an inline implementation. Ask the maintainers of open_filex to either avoid referencing a default implementation via `platforms: macos: default_package: open_filex` or add an inline implementation to open_filex via `platforms: macos:` `pluginClass` or `dartPluginClass`.

Package open_filex:windows references open_filex:windows as the default plugin, but it does not provide an inline implementation. Ask the maintainers of open_filex to either avoid referencing a default implementation via `platforms: windows: default_package: open_filex` or add an inline implementation to open_filex via `platforms: windows:` `pluginClass` or `dartPluginClass`.
```