### PR TITLE
Remove platforms: default_package in pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,11 +24,3 @@ flutter:
         pluginClass: OpenFilePlugin
       ios:
         pluginClass: OpenFilePlugin
-      windows:
-        default_package: dartPluginClass
-      linux:
-        default_package: dartPluginClass
-      macos:
-        default_package: dartPluginClass
-      web:
-        default_package: open_filex


### PR DESCRIPTION
Latest Flutter version from the beta channel (v3.25.0) has a warning with this entries in the pubspec.yaml

```
Package open_filex:linux references dartPluginClass:linux as the default plugin, but the package does not exist.
Ask the maintainers of open_filex to either avoid referencing a default implementation via `platforms: linux: default_package: dartPluginClass` or create a plugin named dartPluginClass.
```

I think this is just not needed.